### PR TITLE
chore: Bump MSRV to 1.60.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.56.0"
+channel = "1.59.0"
 components = [ "clippy", "rustfmt" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.59.0"
+channel = "1.60.0"
 components = [ "clippy", "rustfmt" ]


### PR DESCRIPTION
In order to solve:
`error: package `rayon-core v1.11.0` cannot be built because it requires rustc 1.59 or newer, while the currently active rustc version is 1.56.0`

This is due to the fact that:
```
❯ cargo tree -i rayon-core
rayon-core v1.11.0
└── rayon v1.7.0
    └── criterion v0.3.6
        [dev-dependencies]
        └── bls12_381 v0.8.0
```

As you can see here, `criterion` depends on `rayon_core` with `^0.3`. After `rayon` moved up MSRV without bumping minor version, everything broke.

This bumps the MSRV to 1.59 fixing this issue. See: https://github.com/zkcrypto/bls12_381/issues/112