### PR TITLE
Implement CurveExt for G1Projective

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,8 @@ default-features = false
 
 [dependencies.pasta_curves]
 version = "0.5"
-features = ["alloc"]
+default-features = false
+optional = true
 
 [dependencies.group]
 version = "0.13"
@@ -72,7 +73,7 @@ default = ["groups", "pairings", "alloc", "bits"]
 bits = ["ff/bits"]
 groups = ["group"]
 pairings = ["groups", "pairing"]
-alloc = ["group/alloc"]
+alloc = ["group/alloc", "pasta_curves/alloc"]
 experimental = ["digest"]
 nightly = ["subtle/nightly"]
 basefield = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,10 @@ optional = true
 version = "0.13"
 default-features = false
 
+[dependencies.pasta_curves]
+version = "0.5"
+features = ["alloc"]
+
 [dependencies.group]
 version = "0.13"
 default-features = false

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.61.0"
+channel = "1.66.0"
 components = [ "clippy", "rustfmt" ]

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -93,7 +93,7 @@ impl ConditionallySelectable for Fp {
 
 impl From<u64> for Fp {
     fn from(value: u64) -> Self {
-        Self([value, 0, 0, 0, 0, 0])
+        Self([value, 0, 0, 0, 0, 0]) * R2
     }
 }
 
@@ -141,60 +141,82 @@ const R3: Fp = Fp([
 ]);
 
 /// Fp(1/2)
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex(((1 / 2) * (2^384)) % modulus)
+/// '0x17fbb8571a006596d3916126f2d14ca26e22d1ec31ebb502633cb57c253c276f855000053ab000011804000000015554'
 const TWO_INV: Fp = Fp([
-    0xdcff7fffffffd556,
-    0x0f55ffff58a9ffff,
-    0xb39869507b587b12,
-    0xb23ba5c279c2895f,
-    0x258dd3db21a5d66b,
-    0xd0088f51cbff34d,
+    0x1804000000015554,
+    0x855000053ab00001,
+    0x633cb57c253c276f,
+    0x6e22d1ec31ebb502,
+    0xd3916126f2d14ca2,
+    0x17fbb8571a006596,
 ]);
 
 /// Generator of the field.
-const GENERATOR: Fp = Fp([0x0, 0x0, 0x0, 0x0, 0x0, 0x2]);
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex((2 * (2^384)) % modulus)
+/// '0x11ebab9dbb81e28c6cf28d7901622c038b256521ed1f9bcb57605e0db0ddbb51b93c0018d6c40005321300000006554f'
+const GENERATOR: Fp = Fp([
+    0x321300000006554f,
+    0xb93c0018d6c40005,
+    0x57605e0db0ddbb51,
+    0x8b256521ed1f9bcb,
+    0x6cf28d7901622c03,
+    0x11ebab9dbb81e28c,
+]);
 
 /// Primitive root of unity
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex((GF(modulus)(2) ^ ((modulus - 1) >> 1)) * (2^384))
+/// '0x40ab3263eff0206ef148d1ea0f4c069eca8f3318332bb7a07e83a49a2e99d6932b7fff2ed47fffd43f5fffffffcaaae'
 const ROOT_OF_UNITY: Fp = Fp([
-    0x8527e005bf87356d,
-    0xd867814cd448c6d3,
-    0xae5a5b133eddd420,
-    0x356f43ccc999120f,
-    0xc4296fb7e96da4d6,
-    0x1938c01908424cd8,
+    0x43f5fffffffcaaae,
+    0x32b7fff2ed47fffd,
+    0x07e83a49a2e99d69,
+    0xeca8f3318332bb7a,
+    0xef148d1ea0f4c069,
+    0x40ab3263eff0206,
 ]);
 
 /// Inverse of the primitive root of unity.
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex((1 / (GF(modulus)(2) ^ ((modulus - 1) >> 1))) * (2^384))
+/// '0x40ab3263eff0206ef148d1ea0f4c069eca8f3318332bb7a07e83a49a2e99d6932b7fff2ed47fffd43f5fffffffcaaae'
 const ROOT_OF_UNITY_INV: Fp = Fp([
-    0xded7a779aa2898c8,
-    0x53f260542172180b,
-    0xf05b58c2034dddd6,
-    0x4a7cdeacf037ae72,
-    0x7aa8223a111aeea8,
-    0x5046e6d0c9ac33e,
+    0x43f5fffffffcaaae,
+    0x32b7fff2ed47fffd,
+    0x07e83a49a2e99d69,
+    0xeca8f3318332bb7a,
+    0xef148d1ea0f4c069,
+    0x40ab3263eff0206,
 ]);
 
 /// DELTA
+/// DELTA
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex((GF(modulus)(2) ^ (2 ^ 1)) * (2^384))
+/// '0x9d645513d83de7e8ec9733bbf78ab2fb1d37ebee6ba24d7478fe97a6b0a807f53cc0032fc34000aaa270000000cfff3'
 const DELTA: Fp = Fp([
-    0xca172967c7a255d7,
-    0xa5d11a97b6038a99,
-    0x19e243df219f0178,
-    0x74bc071476d308b7,
-    0x73a18c6550d55c00,
-    0x1536fbfcdcf7f2f5,
+    0xaa270000000cfff3,
+    0x53cc0032fc34000a,
+    0x478fe97a6b0a807f,
+    0xb1d37ebee6ba24d7,
+    0x8ec9733bbf78ab2f,
+    0x9d645513d83de7e,
 ]);
 
 /// ZETA
-// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
-// sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 3)
-// 793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350
-// 5f19672fdf76ce51ba69c6076a0f77eaddb3a93be6f89688de17d813620a00022e01fffffffefffe
+/// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+/// sage: hex((1 / (GF(modulus)(2) ^ ((modulus - 1) // 3))) * (2^384))
+/// '0x18f020655463874103f97d6e83d050d28eb60ebe01bacb9e587042afd3851b955dab22461fcda5d2cd03c9e48671f071'
 const ZETA: Fp = Fp([
-    0x2e01fffffffefffe,
-    0xde17d813620a0002,
-    0xddb3a93be6f89688,
-    0xba69c6076a0f77ea,
-    0x5f19672fdf76ce51,
-    0x0000000000000000,
+    0xcd03c9e48671f071,
+    0x5dab22461fcda5d2,
+    0x587042afd3851b95,
+    0x8eb60ebe01bacb9e,
+    0x03f97d6e83d050d2,
+    0x18f0206554638741,
 ]);
 
 impl<'a> Neg for &'a Fp {
@@ -339,7 +361,7 @@ impl PrimeField for Fp {
     const CAPACITY: u32 = Self::NUM_BITS - 1;
     const TWO_INV: Self = TWO_INV;
     const MULTIPLICATIVE_GENERATOR: Self = GENERATOR;
-    const S: u32 = 32;
+    const S: u32 = 1;
     const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
     const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
     const DELTA: Self = DELTA;

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -184,17 +184,16 @@ const DELTA: Fp = Fp([
 
 /// ZETA
 // sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
-// sage: factor(modulus-1)
-// 2 * 3^2 * 11 * 23 * 47 * 10177 * 859267 * 52437899 * 2584487767265781317813 * 15778400344354997994418419698270088123916926905054652752758194827714659
-// sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 2)
-// 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559786
+// sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 3)
+// 793479390729215512621379701633421447060886740281060493010456487427281649075476305620758731620350
+// 5f19672fdf76ce51ba69c6076a0f77eaddb3a93be6f89688de17d813620a00022e01fffffffefffe
 const ZETA: Fp = Fp([
-    0xb9feffffffffaaaa,
-    0x1eabfffeb153ffff,
-    0x6730d2a0f6b0f624,
-    0x64774b84f38512bf,
-    0x4b1ba7b6434bacd7,
-    0x1a0111ea397fe69a,
+    0x2e01fffffffefffe,
+    0xde17d813620a0002,
+    0xddb3a93be6f89688,
+    0xba69c6076a0f77ea,
+    0x5f19672fdf76ce51,
+    0x0000000000000000,
 ]);
 
 impl<'a> Neg for &'a Fp {
@@ -282,7 +281,7 @@ impl Field for Fp {
     }
 
     fn double(&self) -> Self {
-        self.double()
+        self.add(self)
     }
 
     fn invert(&self) -> CtOption<Self> {
@@ -290,7 +289,7 @@ impl Field for Fp {
     }
 
     fn sqrt_ratio(num: &Self, div: &Self) -> (Choice, Self) {
-        unimplemented!()
+        ff::helpers::sqrt_ratio_generic(num, div)
     }
 
     fn sqrt(&self) -> CtOption<Self> {
@@ -334,8 +333,7 @@ impl PrimeField for Fp {
         Choice::from(self.to_bytes()[0] & 1)
     }
 
-    const MODULUS: &'static str =
-        "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
+    const MODULUS: &'static str = "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
     const NUM_BITS: u32 = 381;
     const CAPACITY: u32 = Self::NUM_BITS - 1;
     const TWO_INV: Self = TWO_INV;

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -320,6 +320,8 @@ impl Field for Fp {
     }
 }
 
+/// This struct represents the [`Fp`] struct serialized as an array of 48 bytes
+/// in Little Endian.
 #[derive(Debug, Clone, Copy)]
 pub struct ReprFp(pub(crate) [u8; 48]);
 
@@ -335,6 +337,20 @@ impl AsRef<[u8]> for ReprFp {
     }
 }
 
+impl AsRef<[u8; 48]> for ReprFp {
+    fn as_ref(&self) -> &[u8; 48] {
+        &self.0
+    }
+}
+
+impl From<[u8; 48]> for ReprFp {
+    fn from(value: [u8; 48]) -> Self {
+        // This uses little endian and so, assumes the array passed in is
+        // in that format.
+        Self(value)
+    }
+}
+
 impl Default for ReprFp {
     fn default() -> Self {
         Self([0u8; 48])
@@ -345,11 +361,15 @@ impl PrimeField for Fp {
     type Repr = ReprFp;
 
     fn from_repr(r: Self::Repr) -> CtOption<Self> {
+        // This uses little endian and so, assumes the array passed in is
+        // in that format.
         Self::from_bytes(&r.0)
     }
 
     fn to_repr(&self) -> Self::Repr {
-        ReprFp(self.to_bytes())
+        let mut le_bytes = self.to_bytes();
+        le_bytes.reverse();
+        ReprFp(le_bytes)
     }
 
     fn is_odd(&self) -> Choice {

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -182,6 +182,21 @@ const DELTA: Fp = Fp([
     0x1536fbfcdcf7f2f5,
 ]);
 
+/// ZETA
+// sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+// sage: factor(modulus-1)
+// 2 * 3^2 * 11 * 23 * 47 * 10177 * 859267 * 52437899 * 2584487767265781317813 * 15778400344354997994418419698270088123916926905054652752758194827714659
+// sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 2)
+// 4002409555221667393417789825735904156556882819939007885332058136124031650490837864442687629129015664037894272559786
+const ZETA: Fp = Fp([
+    0xb9feffffffffaaaa,
+    0x1eabfffeb153ffff,
+    0x6730d2a0f6b0f624,
+    0x64774b84f38512bf,
+    0x4b1ba7b6434bacd7,
+    0x1a0111ea397fe69a,
+]);
+
 impl<'a> Neg for &'a Fp {
     type Output = Fp;
 
@@ -331,9 +346,8 @@ impl PrimeField for Fp {
     const DELTA: Self = DELTA;
 }
 
-// TODO: Fix!
 impl WithSmallOrderMulGroup<3> for Fp {
-    const ZETA: Self = Fp::zero();
+    const ZETA: Self = ZETA;
 }
 
 impl Fp {

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -1,6 +1,7 @@
 //! This module provides an implementation of the BLS12-381 base field `GF(p)`
 //! where `p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab`
 
+#![allow(clippy::needless_borrow)]
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -360,9 +360,10 @@ impl Default for ReprFp {
 impl PrimeField for Fp {
     type Repr = ReprFp;
 
-    fn from_repr(r: Self::Repr) -> CtOption<Self> {
+    fn from_repr(mut r: Self::Repr) -> CtOption<Self> {
         // This uses little endian and so, assumes the array passed in is
         // in that format.
+        r.0.reverse();
         Self::from_bytes(&r.0)
     }
 
@@ -1234,6 +1235,13 @@ fn test_lexicographic_largest() {
         ])
         .lexicographically_largest()
     ));
+}
+
+#[test]
+fn test_repr() {
+    for value in [Fp::ZERO, Fp::ONE, Fp::ROOT_OF_UNITY] {
+        assert_eq!(Fp::from_repr(value.to_repr()).unwrap(), value);
+    }
 }
 
 #[cfg(feature = "zeroize")]

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -878,6 +878,27 @@ impl Fp {
 }
 
 #[test]
+fn test_constants() {
+    assert_eq!(Fp::ONE.double(), GENERATOR);
+    assert_eq!(Fp::ONE, Fp::ONE.double() * TWO_INV);
+    assert_eq!(Fp::ONE, ROOT_OF_UNITY.pow([1 << Fp::S]));
+    assert_eq!(Fp::ONE, ROOT_OF_UNITY * ROOT_OF_UNITY_INV);
+    // sage: modulus = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab
+    // sage: hex((modulus - 1) >> 1)
+    // '0xd0088f51cbff34d258dd3db21a5d66bb23ba5c279c2895fb39869507b587b120f55ffff58a9ffffdcff7fffffffd555'
+    let t = [
+        0xdcff7fffffffd555,
+        0x0f55ffff58a9ffff,
+        0xb39869507b587b12,
+        0xb23ba5c279c2895f,
+        0x258dd3db21a5d66b,
+        0xd0088f51cbff34d,
+    ];
+    assert_eq!(Fp::ONE, DELTA.pow(t));
+    assert_eq!(Fp::ONE, ZETA.pow([3]));
+}
+
+#[test]
 fn test_conditional_selection() {
     let a = Fp([1, 2, 3, 4, 5, 6]);
     let b = Fp([7, 8, 9, 10, 11, 12]);

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -70,7 +70,7 @@ impl ConditionallySelectable for Fp {
 
 impl From<u64> for Fp {
     fn from(value: u64) -> Self {
-        Self([value, 0, 0, 0])
+        Self([value, 0, 0, 0, 0, 0])
     }
 }
 
@@ -261,15 +261,36 @@ impl Field for Fp {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+struct ReprFp(pub(crate) [u8; 48]);
+
+impl AsMut<[u8]> for ReprFp {
+    fn as_mut(&mut self) -> &mut [u8] {
+        &mut self.0[..]
+    }
+}
+
+impl AsRef<[u8]> for ReprFp {
+    fn as_ref(&self) -> &[u8] {
+        &self.0[..]
+    }
+}
+
+impl Default for ReprFp {
+    fn default() -> Self {
+        Self([0u8; 48])
+    }
+}
+
 impl PrimeField for Fp {
-    type Repr = [u8; 32];
+    type Repr = ReprFp;
 
     fn from_repr(r: Self::Repr) -> CtOption<Self> {
-        Self::from_bytes(&r)
+        Self::from_bytes(&r.0)
     }
 
     fn to_repr(&self) -> Self::Repr {
-        self.to_bytes()
+        ReprFp(self.to_bytes())
     }
 
     fn is_odd(&self) -> Choice {
@@ -288,9 +309,10 @@ impl PrimeField for Fp {
     const DELTA: Self = DELTA;
 }
 
-// impl WithSmallOrderMulGroup<2> for Fp {
-//     const ZETA: Self = Fp::zero();
-// }
+// TODO: Fix!
+impl WithSmallOrderMulGroup<3> for Fp {
+    const ZETA: Self = Fp::zero();
+}
 
 impl Fp {
     /// Returns zero, the additive identity.

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -580,7 +580,7 @@ impl Fp {
 
         // Attempt to subtract the modulus, to ensure the value
         // is smaller than the modulus.
-        (&Fp([d0, d1, d2, d3, d4, d5])).subtract_p()
+        (Fp([d0, d1, d2, d3, d4, d5])).subtract_p()
     }
 
     #[inline]

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -1,5 +1,6 @@
 //! This module implements arithmetic over the quadratic extension field Fp2.
 
+#![allow(clippy::needless_borrow)]
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use ff::Field;

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -2,6 +2,7 @@
 
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+use ff::Field;
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -682,6 +682,7 @@ impl CurveExt for G1Projective {
         (self.z * self.y.square() - self.x.square() * self.x)
             .ct_eq(&(self.z.square() * self.z * G1Affine::b()))
             | self.z.is_zero()
+    }
 
     fn b() -> Self::Base {
         B

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -1,5 +1,6 @@
 //! This module provides an implementation of the $\mathbb{G}_1$ group of BLS12-381.
 
+#[cfg(feature = "alloc")]
 use alloc::boxed::Box;
 use core::borrow::Borrow;
 use core::fmt;
@@ -16,6 +17,7 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
 
+#[cfg(feature = "alloc")]
 use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 
 use crate::fp::Fp;
@@ -454,6 +456,7 @@ fn endomorphism(p: &G1Affine) -> G1Affine {
     res
 }
 
+#[cfg(feature = "alloc")]
 impl CurveAffine for G1Affine {
     /// The scalar field of this elliptic curve.
     type ScalarExt = crate::Scalar;
@@ -652,6 +655,7 @@ impl<'a, 'b> Mul<&'b G1Affine> for &'a Scalar {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl CurveExt for G1Projective {
     type ScalarExt = Scalar;
     type Base = Fp;

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -14,6 +14,8 @@ use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
 
+use pasta_curves::arithmetic::CurveExt;
+
 use crate::fp::Fp;
 use crate::Scalar;
 
@@ -586,6 +588,8 @@ impl<'a, 'b> Mul<&'b G1Affine> for &'a Scalar {
         rhs * self
     }
 }
+
+impl CurveExt for G1Projective {}
 
 impl_binops_additive!(G1Projective, G1Projective);
 impl_binops_multiplicative!(G1Projective, Scalar);

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -156,14 +156,14 @@ impl<'a, 'b> Sub<&'b G1Projective> for &'a G1Affine {
 impl Add<G1Affine> for G1Affine {
     type Output = G1Projective;
     fn add(self, rhs: G1Affine) -> Self::Output {
-        self + rhs
+        self.to_curve() + rhs.to_curve()
     }
 }
 
 impl Sub<G1Affine> for G1Affine {
     type Output = G1Projective;
     fn sub(self, rhs: G1Affine) -> Self::Output {
-        self - rhs
+        self + -rhs
     }
 }
 
@@ -660,7 +660,7 @@ impl CurveExt for G1Projective {
     const CURVE_ID: &'static str = "Bls12-381";
 
     fn endo(&self) -> Self {
-        self.endo()
+        endomorphism(&G1Affine::from(self)).into()
     }
 
     fn jacobian_coordinates(&self) -> (Fp, Fp, Fp) {
@@ -670,7 +670,8 @@ impl CurveExt for G1Projective {
         (x, y, self.z)
     }
 
-    fn hash_to_curve<'a>(domain_prefix: &'a str) -> Box<dyn Fn(&[u8]) -> Self + 'a> {
+    fn hash_to_curve<'a>(_domain_prefix: &'a str) -> Box<dyn Fn(&[u8]) -> Self + 'a> {
+        // XXX: TODO
         unimplemented!()
     }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -258,8 +258,8 @@ impl G2Affine {
 
         let mut res = [0; 96];
 
-        (&mut res[0..48]).copy_from_slice(&x.c1.to_bytes()[..]);
-        (&mut res[48..96]).copy_from_slice(&x.c0.to_bytes()[..]);
+        res[0..48].copy_from_slice(&x.c1.to_bytes()[..]);
+        res[48..96].copy_from_slice(&x.c0.to_bytes()[..]);
 
         // This point is in compressed form, so we set the most significant bit.
         res[0] |= 1u8 << 7;

--- a/src/hash_to_curve/expand_msg.rs
+++ b/src/hash_to_curve/expand_msg.rs
@@ -41,7 +41,7 @@ impl<'x, L: ArrayLength<u8>> ExpandMsgDst<'x, L> {
             let mut data = GenericArray::<u8, L>::default();
             H::default()
                 .chain(OVERSIZE_DST_SALT)
-                .chain(&dst)
+                .chain(dst)
                 .finalize_xof_dirty()
                 .read(&mut data);
             Self::Hashed(data)
@@ -56,7 +56,7 @@ impl<'x, L: ArrayLength<u8>> ExpandMsgDst<'x, L> {
         H: Digest<OutputSize = L>,
     {
         if dst.len() > 255 {
-            Self::Hashed(H::new().chain(OVERSIZE_DST_SALT).chain(&dst).finalize())
+            Self::Hashed(H::new().chain(OVERSIZE_DST_SALT).chain(dst).finalize())
         } else {
             Self::Raw(dst)
         }

--- a/src/hash_to_curve/map_g1.rs
+++ b/src/hash_to_curve/map_g1.rs
@@ -842,7 +842,7 @@ fn test_encode_to_curve_10() {
 
     for case in cases {
         let g = <G1Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::encode_to_curve(
-            &case.msg, DOMAIN,
+            case.msg, DOMAIN,
         );
         let aff = G1Affine::from(g);
         let g_uncompressed = aff.to_uncompressed();
@@ -923,7 +923,7 @@ fn test_hash_to_curve_10() {
 
     for case in cases {
         let g = <G1Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(
-            &case.msg, DOMAIN,
+            case.msg, DOMAIN,
         );
         let g_uncompressed = G1Affine::from(g).to_uncompressed();
 

--- a/src/hash_to_curve/map_g1.rs
+++ b/src/hash_to_curve/map_g1.rs
@@ -7,6 +7,7 @@ use super::{HashToField, MapToCurve, Sgn0};
 use crate::fp::Fp;
 use crate::g1::G1Projective;
 use crate::generic_array::{typenum::U64, GenericArray};
+use ff::Field;
 
 /// Coefficients of the 11-isogeny x map's numerator
 const ISO11_XNUM: [Fp; 12] = [

--- a/src/hash_to_curve/map_g2.rs
+++ b/src/hash_to_curve/map_g2.rs
@@ -9,6 +9,7 @@ use crate::generic_array::{
     GenericArray,
 };
 use crate::{fp::Fp, fp2::Fp2, g2::G2Projective};
+use ff::Field;
 
 /// Coefficients of the 3-isogeny x map's numerator
 const ISO3_XNUM: [Fp2; 4] = [

--- a/src/hash_to_curve/map_g2.rs
+++ b/src/hash_to_curve/map_g2.rs
@@ -610,7 +610,7 @@ fn test_encode_to_curve_10() {
 
     for case in cases {
         let g = <G2Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::encode_to_curve(
-            &case.msg, DOMAIN,
+            case.msg, DOMAIN,
         );
         let g_uncompressed = G2Affine::from(g).to_uncompressed();
 
@@ -700,7 +700,7 @@ fn test_hash_to_curve_10() {
 
     for case in cases {
         let g = <G2Projective as HashToCurve<ExpandMsgXmd<sha2::Sha256>>>::hash_to_curve(
-            &case.msg, DOMAIN,
+            case.msg, DOMAIN,
         );
         let g_uncompressed = G2Affine::from(g).to_uncompressed();
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -5,7 +5,7 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 
-use ff::{Field, PrimeField};
+use ff::{Field, PrimeField, WithSmallOrderMulGroup};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "bits")]
@@ -710,6 +710,11 @@ impl PrimeField for Scalar {
     const ROOT_OF_UNITY: Self = ROOT_OF_UNITY;
     const ROOT_OF_UNITY_INV: Self = ROOT_OF_UNITY_INV;
     const DELTA: Self = DELTA;
+}
+
+impl WithSmallOrderMulGroup<3> for Scalar {
+    // TODO: Fix
+    const ZETA: Self = Scalar::zero();
 }
 
 #[cfg(all(feature = "bits", not(target_pointer_width = "64")))]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -243,6 +243,15 @@ const DELTA: Scalar = Scalar([
     0x6185_d066_27c0_67cb,
 ]);
 
+/// ZETA
+// sage: modulus = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
+//sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 3)
+//228988810152649578064853576960394133503
+//sage: print(228988810152649578064853576960394133503.hex())
+//ac45a4010001a40200000000ffffffff
+// Also test with N=2 -> 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000
+const ZETA: Scalar = Scalar([0x00000000ffffffff, 0xac45a4010001a402, 0x0, 0x0]);
+
 impl Default for Scalar {
     #[inline]
     fn default() -> Self {
@@ -736,7 +745,7 @@ impl PrimeField for Scalar {
 
 impl WithSmallOrderMulGroup<3> for Scalar {
     // TODO: Fix
-    const ZETA: Self = Scalar::zero();
+    const ZETA: Self = ZETA;
 }
 
 #[cfg(all(feature = "bits", not(target_pointer_width = "64")))]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -699,7 +699,7 @@ impl Field for Scalar {
         // (t - 1) // 2 = 6104339283789297388802252303364915521546564123189034618274734669823
         ff::helpers::sqrt_tonelli_shanks(
             self,
-            &[
+            [
                 0x7fff_2dff_7fff_ffff,
                 0x04d0_ec02_a9de_d201,
                 0x94ce_bea4_199c_ec04,

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,6 +1,7 @@
 //! This module provides an implementation of the BLS12-381 scalar field $\mathbb{F}_q$
 //! where `q = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
 
+use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
@@ -57,6 +58,27 @@ impl PartialEq for Scalar {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
         bool::from(self.ct_eq(other))
+    }
+}
+
+impl Ord for Scalar {
+    fn cmp(&self, other: &Self) -> Ordering {
+        let left = self.to_repr();
+        let right = other.to_repr();
+        left.iter()
+            .zip(right.iter())
+            .rev()
+            .find_map(|(left_byte, right_byte)| match left_byte.cmp(right_byte) {
+                Ordering::Equal => None,
+                res => Some(res),
+            })
+            .unwrap_or(Ordering::Equal)
+    }
+}
+
+impl PartialOrd for Scalar {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -742,7 +742,6 @@ impl PrimeField for Scalar {
 }
 
 impl WithSmallOrderMulGroup<3> for Scalar {
-    // TODO: Fix
     const ZETA: Self = ZETA;
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -250,7 +250,12 @@ const DELTA: Scalar = Scalar([
 //sage: print(228988810152649578064853576960394133503.hex())
 //ac45a4010001a40200000000ffffffff
 // Also test with N=2 -> 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000
-const ZETA: Scalar = Scalar([0x00000000ffffffff, 0xac45a4010001a402, 0x0, 0x0]);
+const ZETA: Scalar = Scalar([
+    0xffffffff00000000,
+    0x53bda402fffe5bfe,
+    0x3339d80809a1d805,
+    0x73eda753299d7d48,
+]);
 
 impl Default for Scalar {
     #[inline]

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -1,6 +1,7 @@
 //! This module provides an implementation of the BLS12-381 scalar field $\mathbb{F}_q$
 //! where `q = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001`
 
+#![allow(clippy::needless_borrow)]
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -247,15 +247,7 @@ const DELTA: Scalar = Scalar([
 // sage: modulus = 0x73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000001
 //sage: GF(modulus).primitive_element() ^ ((modulus - 1) // 3)
 //228988810152649578064853576960394133503
-//sage: print(228988810152649578064853576960394133503.hex())
-//ac45a4010001a40200000000ffffffff
-// Also test with N=2 -> 73eda753299d7d483339d80809a1d80553bda402fffe5bfeffffffff00000000
-const ZETA: Scalar = Scalar([
-    0xffffffff00000000,
-    0x53bda402fffe5bfe,
-    0x3339d80809a1d805,
-    0x73eda753299d7d48,
-]);
+const ZETA: Scalar = Scalar::from_raw([0x00000000ffffffff, 0xac45a4010001a402, 0, 0]);
 
 impl Default for Scalar {
     #[inline]


### PR DESCRIPTION
This monstrosity which makes almost no-sense (Bls12-381 depending on pasta-curves) is the workaround that unblocks Bls12-381 usage in halo2curves.

For more context on the unblock, see: https://github.com/zkcrypto/group/pull/48 && https://github.com/privacy-scaling-explorations/halo2curves/issues/75

Left to do for the future:
- [ ] `hash_to_curve` impl within `CurveExt` impl.