### PR TITLE
feat(fp): add FromUniformBytes<64> trait

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -392,10 +392,10 @@ impl WithSmallOrderMulGroup<3> for Fp {
     const ZETA: Self = ZETA;
 }
 
-impl FromUniformBytes<96> for Fp {
-    /// Converts a 768-bit big endian endian integer into
+impl FromUniformBytes<64> for Fp {
+    /// Converts a 512-bit big endian endian integer into
     /// an `Fp` by reducing by the modulus.
-    fn from_uniform_bytes(bytes: &[u8; 96]) -> Self {
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
         // Parse the random bytes as a big-endian number, to match Fp encoding order.
         Self::from_u768([
             u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[0..8]).unwrap()),
@@ -406,13 +406,14 @@ impl FromUniformBytes<96> for Fp {
             u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[40..48]).unwrap()),
             u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[48..56]).unwrap()),
             u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[56..64]).unwrap()),
-            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[64..72]).unwrap()),
-            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[72..80]).unwrap()),
-            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[80..88]).unwrap()),
-            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[88..96]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[0..8]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[8..16]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[16..24]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[24..32]).unwrap()),
         ])
     }
 }
+
 impl Fp {
     /// Returns zero, the additive identity.
     #[inline]

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -392,10 +392,10 @@ impl WithSmallOrderMulGroup<3> for Fp {
     const ZETA: Self = ZETA;
 }
 
-impl FromUniformBytes<64> for Fp {
+impl FromUniformBytes<96> for Fp {
     /// Converts a 768-bit big endian endian integer into
     /// an `Fp` by reducing by the modulus.
-    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+    fn from_uniform_bytes(bytes: &[u8; 96]) -> Self {
         // Parse the random bytes as a big-endian number, to match Fp encoding order.
         Self::from_u768([
             u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[0..8]).unwrap()),

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -5,7 +5,7 @@
 use core::cmp::Ordering;
 use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
-use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+use ff::{Field, FromUniformBytes, PrimeField, WithSmallOrderMulGroup};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -392,6 +392,27 @@ impl WithSmallOrderMulGroup<3> for Fp {
     const ZETA: Self = ZETA;
 }
 
+impl FromUniformBytes<64> for Fp {
+    /// Converts a 768-bit big endian endian integer into
+    /// an `Fp` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        // Parse the random bytes as a big-endian number, to match Fp encoding order.
+        Self::from_u768([
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[0..8]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[8..16]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[16..24]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[24..32]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[32..40]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[40..48]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[48..56]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[56..64]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[64..72]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[72..80]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[80..88]).unwrap()),
+            u64::from_be_bytes(<[u8; 8]>::try_from(&bytes[88..96]).unwrap()),
+        ])
+    }
+}
 impl Fp {
     /// Returns zero, the additive identity.
     #[inline]

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -13,6 +13,9 @@ use group::{
 };
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
+use alloc::vec::Vec;
+use std::io::Read;
+use std::io::Write;
 
 #[cfg(feature = "alloc")]
 use group::WnafGroup;
@@ -1893,4 +1896,46 @@ fn test_commutative_scalar_subgroup_multiplication() {
     // By value.
     assert_eq!(g1_p * a, a * g1_p);
     assert_eq!(g1_a * a, a * g1_a);
+}
+
+
+impl crate::serde::SerdeObject for G1Affine {
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from bytes as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. As such this function should only be
+    /// used internally as an extension of machine memory. It should not be used to deserialize
+    /// externally provided data.
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+        G1Affine::from_compressed(bytes.try_into().unwrap()).unwrap()
+    }
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+        Some(G1Affine::from_compressed(bytes.try_into().unwrap()).unwrap())
+    }
+
+    fn to_raw_bytes(&self) -> Vec<u8> {
+        self.to_compressed().into()
+    }
+
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from disk as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. This function should only be used
+    /// internally when some machine state cannot be kept in memory (e.g., between runs)
+    /// and needs to be reloaded as quickly as possible.
+    fn read_raw_unchecked<R: ::std::io::Read>(reader: &mut R) -> Self {
+        let mut buf = [0; 48];
+        reader.read_exact(&mut buf).unwrap();
+        G1Affine::from_compressed(&buf).unwrap()
+
+    }
+    fn read_raw<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut buf = [0; 48];
+        reader.read_exact(&mut buf).unwrap();
+        Ok(G1Affine::from_compressed(&buf).unwrap())
+    }
+
+    fn write_raw<W: Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        writer.write_all(&self.to_compressed())?;
+        Ok(())
+
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 //! * This implementation does not require the Rust standard library.
 //! * All operations are constant time unless explicitly noted.
 
-#![no_std]
+
 #![cfg_attr(docsrs, feature(doc_cfg))]
 // Catch documentation errors caused by code changes.
 #![deny(rustdoc::broken_intra_doc_links)]
@@ -36,6 +36,8 @@ mod tests;
 
 #[macro_use]
 mod util;
+
+mod serde;
 
 /// Notes about how the BLS12-381 elliptic curve is designed, specified
 /// and implemented by this library.

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -679,7 +679,7 @@ impl Scalar {
         Self(inner)
     }
     /// From raw bytes
-    fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+    pub fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
         if bytes.len() != 32 {
             return None;
         }
@@ -687,7 +687,7 @@ impl Scalar {
         Self::is_less_than(&elt.0, &MODULUS.0).then(|| elt)
     }
     /// To raw bytes
-    fn to_raw_bytes(&self) -> Vec<u8> {
+    pub fn to_raw_bytes(&self) -> Vec<u8> {
         let mut res = Vec::with_capacity(32);
         for limb in self.0.iter() {
             res.extend_from_slice(&limb.to_le_bytes());
@@ -695,7 +695,7 @@ impl Scalar {
         res
     }
     /// Read raw unchecked
-    fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+    pub fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
         let inner = [(); 4].map(|_| {
             let mut buf = [0; 8];
             reader.read_exact(&mut buf).unwrap();

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -670,7 +670,8 @@ impl Scalar {
         borrow >> 63 == 1
     }
 
-    fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+    /// Read raw bytes.
+    pub fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut inner = [0u64; 4];
         for limb in inner.iter_mut() {
             let mut buf = [0; 8];
@@ -687,7 +688,8 @@ impl Scalar {
                 )
             })
     }
-    fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+    /// Write raw bytes.
+    pub fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
         for limb in self.0.iter() {
             writer.write_all(&limb.to_le_bytes())?;
         }

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -7,7 +7,7 @@ use core::fmt;
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 use rand_core::RngCore;
 
-use ff::{Field, PrimeField, WithSmallOrderMulGroup};
+use ff::{Field, PrimeField, WithSmallOrderMulGroup, FromUniformBytes};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 #[cfg(feature = "bits")]
@@ -786,6 +786,23 @@ impl Field for Scalar {
 
     fn is_zero_vartime(&self) -> bool {
         self.0 == Self::zero().0
+    }
+}
+
+impl FromUniformBytes<64> for Scalar {
+    /// Converts a 512-bit little endian integer into
+    /// an `Fq` by reducing by the modulus.
+    fn from_uniform_bytes(bytes: &[u8; 64]) -> Self {
+        Self::from_u512([
+            u64::from_le_bytes(bytes[0..8].try_into().unwrap()),
+            u64::from_le_bytes(bytes[8..16].try_into().unwrap()),
+            u64::from_le_bytes(bytes[16..24].try_into().unwrap()),
+            u64::from_le_bytes(bytes[24..32].try_into().unwrap()),
+            u64::from_le_bytes(bytes[32..40].try_into().unwrap()),
+            u64::from_le_bytes(bytes[40..48].try_into().unwrap()),
+            u64::from_le_bytes(bytes[48..56].try_into().unwrap()),
+            u64::from_le_bytes(bytes[56..64].try_into().unwrap()),
+        ])
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -654,6 +654,12 @@ impl Scalar {
 
         Scalar([d0 & mask, d1 & mask, d2 & mask, d3 & mask])
     }
+
+    /// Size of the field
+    #[inline]
+    pub const fn size() -> usize {
+        32
+    }
 }
 
 impl From<Scalar> for [u8; 32] {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,26 @@
+use std;
+use std::io::{self, Read, Write};
+
+/// Trait for converting raw bytes to/from the internal representation of a type.
+/// For example, field elements are represented in Montgomery form and serialized/deserialized without Montgomery reduction.
+pub trait SerdeObject: Sized {
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from bytes as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. As such this function should only be
+    /// used internally as an extension of machine memory. It should not be used to deserialize
+    /// externally provided data.
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self;
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self>;
+
+    fn to_raw_bytes(&self) -> Vec<u8>;
+
+    /// The purpose of unchecked functions is to read the internal memory representation
+    /// of a type from disk as quickly as possible. No sanitization checks are performed
+    /// to ensure the bytes represent a valid object. This function should only be used
+    /// internally when some machine state cannot be kept in memory (e.g., between runs)
+    /// and needs to be reloaded as quickly as possible.
+    fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self;
+    fn read_raw<R: Read>(reader: &mut R) -> io::Result<Self>;
+
+    fn write_raw<W: Write>(&self, writer: &mut W) -> io::Result<()>;
+}


### PR DESCRIPTION
I noticed this is missing when I tried tweaking https://github.com/kilic/halo2msm to bls12-381

Although MockProver::run is still failing due to an error on constraints:

```
running 1 test
fixed mul gate, window 6, # terms: 256, row cost: 130, area cost: 654
Equality constraint not satisfied by cell (Column('Advice', 0 - ), in Region 0 ('app') at offset 0)

Equality constraint not satisfied by cell (Column('Advice', 1 - ), in Region 0 ('app') at offset 0)

thread 'msm_fix::tests::test_fixed_msm' panicked at /Users/admin/.cargo/git/checkouts/halo2-afe2d0b0be6b3c3a/0b75a92/halo2_frontend/src/dev.rs:1217:13:
circuit was not satisfied
```

This could be due to passing bls12-381 bases points where it should be (in the case of verkle) bandersnatch points (since base field of bandersnatch is native to scalar of bls12-381) 


Code is here:
https://github.com/dragan2234/halo2msm/pull/1/files#diff-7538a57bed83a5d5b5c630977f536c7d44f9d62aff4325808f072cc02a0be248R225

cc @CPerezz 
